### PR TITLE
Allow TSV files to be loaded when default encoding is non-UTF-8

### DIFF
--- a/text2phonemesequence/text2phonemesequence.py
+++ b/text2phonemesequence/text2phonemesequence.py
@@ -18,7 +18,7 @@ class Text2PhonemeSequence:
         if not os.path.exists('./' + language + ".tsv"):
             os.system("wget https://raw.githubusercontent.com/lingjzhu/CharsiuG2P/main/dicts/" + language + ".tsv")
         if os.path.exists('./' + language + ".tsv"):
-            f = open("./" + language + ".tsv", "r")
+            f = open("./" + language + ".tsv", "r", encoding="utf-8")
             list_words = f.read().strip().split("\n")
             f.close()
             for word_phone in list_words:


### PR DESCRIPTION
This fixes the following error, which I encountered on a machine with a default file encoding of ASCII:

```
File /opt/conda/lib/python3.10/site-packages/text2phonemesequence/text2phonemesequence.py:22, in Text2PhonemeSequence.__init__(self, pretrained_g2p_model, tokenizer, language, is_cuda)
     20 if os.path.exists('./' + language + ".tsv"):
     21     f = open("./" + language + ".tsv", "r")
---> 22     list_words = f.read().strip().split("\n")
     23     f.close()
     24     for word_phone in list_words:

File /opt/conda/lib/python3.10/encodings/ascii.py:26, in IncrementalDecoder.decode(self, input, final)
     25 def decode(self, input, final=False):
---> 26     return codecs.ascii_decode(input, self.errors)[0]

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc9 in position 8: ordinal not in range(128)
```